### PR TITLE
Fix incorrect types in NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "2.0.0",
     "description": "Minehut API wrapper for TypeScript",
     "main": "dist/src/index.js",
-    "types": "dist/src/index.ts.d",
+    "types": "dist/src/index.d.ts",
     "repository": "git@github.com:ronthecookie/minehut-api.git",
     "author": "Ron B <me@ronthecookie.me>",
     "license": "LGPL-3.0",


### PR DESCRIPTION
I think this was a typo -- when I ran `tsc`, the generated types file was `dist/src/index.d.ts`, and the path in the package.json pointed to a non-existent file (at least in my env), if the file is existent in other people's environments, sorry for this invalid PR!